### PR TITLE
fix config bug in docs/tutorials/finetune.md

### DIFF
--- a/docs/tutorials/finetune.md
+++ b/docs/tutorials/finetune.md
@@ -34,8 +34,10 @@ model = dict(
             fc_out_channels=1024,
             roi_feat_size=7,
             num_classes=8,
-            target_means=[0., 0., 0., 0.],
-            target_stds=[0.1, 0.1, 0.2, 0.2],
+            bbox_coder=dict(
+                type='DeltaXYWHBBoxCoder',
+                target_means=[0., 0., 0., 0.],
+                target_stds=[0.1, 0.1, 0.2, 0.2]),
             reg_class_agnostic=False,
             loss_cls=dict(
                 type='CrossEntropyLoss', use_sigmoid=False, loss_weight=1.0),


### PR DESCRIPTION
`target_means` and `target_stds` should be in bbox_coder according to
https://github.com/open-mmlab/mmdetection/blob/2b6f6616f804beaca3dbf071fa398c586243db13/configs/_base_/models/mask_rcnn_r50_fpn.py#L48